### PR TITLE
Fix console bridge dependency tag

### DIFF
--- a/tesseract_rviz/package.xml
+++ b/tesseract_rviz/package.xml
@@ -16,7 +16,8 @@
   <depend>tesseract_msgs</depend>
   <depend>tesseract_monitoring</depend>
   <depend>tesseract_rosutils</depend>
-  <depend>Qt5</depend>
+  <depend>libqt5-core</depend>
+  <depend>libqt5-widgets</depend>
   <depend>libconsole-bridge-dev</depend>
 
   <export>

--- a/tesseract_rviz/package.xml
+++ b/tesseract_rviz/package.xml
@@ -17,7 +17,7 @@
   <depend>tesseract_monitoring</depend>
   <depend>tesseract_rosutils</depend>
   <depend>Qt5</depend>
-  <depend>libconsole-bridge</depend>
+  <depend>libconsole-bridge-dev</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/tesseract_rviz/package.xml
+++ b/tesseract_rviz/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
   <depend>rviz2</depend>
-  <depend>message_generation</depend>
   <depend>pluginlib</depend>
   <depend>interactive_markers</depend>
   <depend>tesseract_msgs</depend>


### PR DESCRIPTION
The branch currently fails CI because the rosdep key for console bridge is not correct